### PR TITLE
fix get_regulatory_domain part

### DIFF
--- a/regdomain.sh
+++ b/regdomain.sh
@@ -33,6 +33,9 @@ regulatory_domain=BZ
 ############################## END OF USER CONFIG SECTION ##############################
 
 #Custom function to set regulatory domain
+function get_regulatory_domain() {
+	current_regulatory_domain="$(iw reg get | grep -m1 "country" | awk -F' ' '{print $2}' | awk -F':' '{print $1}')"
+}
 function set_regulatory_domain() {
 
 	debug_print
@@ -40,7 +43,7 @@ function set_regulatory_domain() {
 	language_strings "${language}" "regdomain_text_0" "blue"
 
 	#Get current regulatory domain
-	current_regulatory_domain="$(iw reg get | grep "country" | awk -F' ' '{print $2}' | awk -F':' '{print $1}')"
+	get_regulatory_domain
 	if [ -z "${regulatory_domain}" ]; then
 		regulatory_domain="${current_regulatory_domain}"
 	fi
@@ -63,7 +66,7 @@ function set_regulatory_domain() {
 			done
 		fi
 		#Check regulatory domain again
-		current_regulatory_domain="$(iw reg get | grep "country" | awk -F' ' '{print $2}' | awk -F':' '{print $1}')"
+		get_regulatory_domain
 		if [ "${current_regulatory_domain}" != "${regulatory_domain}" ]; then
 			language_strings "${language}" "regdomain_text_1" "red"
 		fi


### PR DESCRIPTION
In my case:
```
$ iw reg get   
global
country BR: DFS-FCC
        (2402 - 2482 @ 40), (N/A, 20), (N/A)
        (5170 - 5250 @ 80), (N/A, 17), (N/A), AUTO-BW
        (5250 - 5330 @ 80), (N/A, 24), (0 ms), DFS, AUTO-BW
        (5490 - 5730 @ 160), (N/A, 24), (0 ms), DFS
        (5735 - 5835 @ 80), (N/A, 30), (N/A)

phy#0
country 00: DFS-UNSET
        (2402 - 2472 @ 40), (N/A, 20), (N/A)
        (2457 - 2482 @ 20), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
        (2474 - 2494 @ 20), (N/A, 20), (N/A), NO-OFDM, PASSIVE-SCAN
        (5170 - 5250 @ 80), (N/A, 20), (N/A), AUTO-BW, PASSIVE-SCAN
        (5250 - 5330 @ 80), (N/A, 20), (0 ms), DFS, AUTO-BW, PASSIVE-SCAN
        (5490 - 5730 @ 160), (N/A, 20), (0 ms), DFS, PASSIVE-SCAN
        (5735 - 5835 @ 80), (N/A, 20), (N/A), PASSIVE-SCAN
        (57240 - 63720 @ 2160), (N/A, 0), (N/A)
```

Result of command ```iw reg get | grep "country" | awk -F' ' '{print $2}' | awk -F':' '{print $1}')``` - is two-element string, separated by newline char.
Bash incorrectly compare those lines in set_regulatory_domain function.
Option "-m1" for grep allow selection only first line - from global section of ```iw reg get``` command.